### PR TITLE
Create modern player-focused dashboard with DPS tracking

### DIFF
--- a/src/main/java/realmshark/RealmShark.java
+++ b/src/main/java/realmshark/RealmShark.java
@@ -1,0 +1,25 @@
+package realmshark;
+
+import realmshark.service.SnifferController;
+import realmshark.ui.RealmSharkFrame;
+
+import javax.swing.SwingUtilities;
+
+/**
+ * Application entry point that boots the modern RealmShark UI.
+ */
+public class RealmShark {
+
+    public static void main(String[] args) {
+        try {
+            javax.swing.UIManager.setLookAndFeel(javax.swing.UIManager.getSystemLookAndFeelClassName());
+        } catch (Exception ignored) {
+        }
+
+        SwingUtilities.invokeLater(() -> {
+            SnifferController controller = new SnifferController();
+            RealmSharkFrame frame = new RealmSharkFrame(controller);
+            frame.setVisible(true);
+        });
+    }
+}

--- a/src/main/java/realmshark/model/PlayerSnapshot.java
+++ b/src/main/java/realmshark/model/PlayerSnapshot.java
@@ -1,0 +1,57 @@
+package realmshark.model;
+
+/**
+ * Immutable view of the tracked player that can safely be shared with the UI layer.
+ */
+public class PlayerSnapshot {
+    public final int objectId;
+    public final String accountId;
+    public final String name;
+    public final String guild;
+    public final String playerClass;
+    public final int level;
+    public final int currentHp;
+    public final int maxHp;
+    public final long totalDamage;
+    public final long totalHealing;
+    public final double dps;
+    public final double hps;
+    public final boolean tracked;
+    public final boolean active;
+    public final long lastSeen;
+    public final int objectType;
+
+    public PlayerSnapshot(int objectId,
+                          String accountId,
+                          String name,
+                          String guild,
+                          String playerClass,
+                          int level,
+                          int currentHp,
+                          int maxHp,
+                          long totalDamage,
+                          long totalHealing,
+                          double dps,
+                          double hps,
+                          boolean tracked,
+                          boolean active,
+                          long lastSeen,
+                          int objectType) {
+        this.objectId = objectId;
+        this.accountId = accountId;
+        this.name = name;
+        this.guild = guild;
+        this.playerClass = playerClass;
+        this.level = level;
+        this.currentHp = currentHp;
+        this.maxHp = maxHp;
+        this.totalDamage = totalDamage;
+        this.totalHealing = totalHealing;
+        this.dps = dps;
+        this.hps = hps;
+        this.tracked = tracked;
+        this.active = active;
+        this.lastSeen = lastSeen;
+        this.objectType = objectType;
+    }
+}

--- a/src/main/java/realmshark/model/TrackedPlayer.java
+++ b/src/main/java/realmshark/model/TrackedPlayer.java
@@ -1,0 +1,199 @@
+package realmshark.model;
+
+import packets.data.StatData;
+import packets.data.enums.StatType;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Runtime model representing a single player in the sniffer session.
+ */
+public class TrackedPlayer {
+
+    private static final long WINDOW_MS = 10_000L;
+
+    private final int objectId;
+    private String accountId = "";
+    private String name = "Unknown";
+    private String guild = "";
+    private String playerClass = "";
+    private int level = 0;
+    private int currentHp = -1;
+    private int maxHp = -1;
+    private boolean active = true;
+    private long lastSeen = System.currentTimeMillis();
+    private int objectType;
+
+    private final Deque<Sample> damageSamples = new ArrayDeque<>();
+    private final Deque<Sample> healingSamples = new ArrayDeque<>();
+    private long totalDamage;
+    private long totalHealing;
+    private int rollingDamage;
+    private int rollingHealing;
+
+    public TrackedPlayer(int objectId) {
+        this.objectId = objectId;
+    }
+
+    public int getObjectId() {
+        return objectId;
+    }
+
+    public synchronized String getName() {
+        return name;
+    }
+
+    public synchronized boolean isActive() {
+        return active;
+    }
+
+    public synchronized void markInactive() {
+        this.active = false;
+    }
+
+    public synchronized void updateFromStats(StatData[] stats) {
+        long now = System.currentTimeMillis();
+        lastSeen = now;
+        active = true;
+
+        for (StatData stat : stats) {
+            StatType type = stat.statType;
+            if (type == null) {
+                continue;
+            }
+            switch (type) {
+                case NAME_STAT:
+                    if (stat.stringStatValue != null && !stat.stringStatValue.isEmpty()) {
+                        name = stat.stringStatValue;
+                    }
+                    break;
+                case GUILD_NAME_STAT:
+                    guild = stat.stringStatValue == null ? "" : stat.stringStatValue;
+                    break;
+                case ACCOUNT_ID_STAT:
+                    accountId = stat.stringStatValue == null ? accountId : stat.stringStatValue;
+                    break;
+                case HP_STAT:
+                    handleHp(stat.statValue, now);
+                    break;
+                case MAX_HP_STAT:
+                    maxHp = stat.statValue;
+                    break;
+                case LEVEL_STAT:
+                    level = stat.statValue;
+                    break;
+                case SKIN_ID:
+                    // fallthrough intended. The skin determines the class name; we expect objectType to be provided elsewhere.
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    public synchronized void setObjectType(int objectType, String resolvedName) {
+        this.objectType = objectType;
+        if (resolvedName != null && !resolvedName.isEmpty()) {
+            this.playerClass = resolvedName;
+        }
+    }
+
+    private void handleHp(int newHp, long now) {
+        if (currentHp >= 0 && newHp > currentHp) {
+            recordHealing(newHp - currentHp, now);
+        }
+        currentHp = newHp;
+    }
+
+    public synchronized void recordDamage(int amount) {
+        if (amount <= 0) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        damageSamples.addLast(new Sample(now, amount));
+        rollingDamage += amount;
+        totalDamage += amount;
+        prune(damageSamples, now, true);
+        lastSeen = now;
+    }
+
+    private void recordHealing(int amount, long now) {
+        if (amount <= 0) {
+            return;
+        }
+        healingSamples.addLast(new Sample(now, amount));
+        rollingHealing += amount;
+        totalHealing += amount;
+        prune(healingSamples, now, false);
+    }
+
+    private void prune(Deque<Sample> samples, long now, boolean damageQueue) {
+        while (!samples.isEmpty() && now - samples.peekFirst().timestamp > WINDOW_MS) {
+            Sample removed = samples.removeFirst();
+            if (damageQueue) {
+                rollingDamage -= removed.amount;
+            } else {
+                rollingHealing -= removed.amount;
+            }
+        }
+    }
+
+    public synchronized double getDps() {
+        long now = System.currentTimeMillis();
+        prune(damageSamples, now, true);
+        if (damageSamples.isEmpty()) {
+            return 0d;
+        }
+        long window = Math.max(1000L, Math.min(WINDOW_MS, now - damageSamples.peekFirst().timestamp + 1));
+        return rollingDamage * 1000d / window;
+    }
+
+    public synchronized double getHps() {
+        long now = System.currentTimeMillis();
+        prune(healingSamples, now, false);
+        if (healingSamples.isEmpty()) {
+            return 0d;
+        }
+        long window = Math.max(1000L, Math.min(WINDOW_MS, now - healingSamples.peekFirst().timestamp + 1));
+        return rollingHealing * 1000d / window;
+    }
+
+    public synchronized PlayerSnapshot toSnapshot(boolean tracked) {
+        long now = System.currentTimeMillis();
+        prune(damageSamples, now, true);
+        prune(healingSamples, now, false);
+        return new PlayerSnapshot(
+                objectId,
+                accountId,
+                name,
+                guild,
+                playerClass,
+                level,
+                currentHp,
+                maxHp,
+                totalDamage,
+                totalHealing,
+                getDps(),
+                getHps(),
+                tracked,
+                active,
+                lastSeen,
+                objectType
+        );
+    }
+
+    public synchronized void markSeen() {
+        lastSeen = System.currentTimeMillis();
+    }
+
+    private static class Sample {
+        private final long timestamp;
+        private final int amount;
+
+        private Sample(long timestamp, int amount) {
+            this.timestamp = timestamp;
+            this.amount = amount;
+        }
+    }
+}

--- a/src/main/java/realmshark/service/PlayerTracker.java
+++ b/src/main/java/realmshark/service/PlayerTracker.java
@@ -1,0 +1,153 @@
+package realmshark.service;
+
+import assets.IdToAsset;
+import packets.data.ObjectData;
+import packets.data.ObjectStatusData;
+import packets.data.StatData;
+import packets.data.enums.StatType;
+import packets.incoming.DamagePacket;
+import packets.incoming.NewTickPacket;
+import packets.incoming.UpdatePacket;
+import realmshark.model.PlayerSnapshot;
+import realmshark.model.TrackedPlayer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Aggregates player state from incoming packets and exposes immutable snapshots for the UI.
+ */
+public class PlayerTracker {
+
+    private final Map<Integer, TrackedPlayer> playersByObjectId = new HashMap<>();
+    private final Map<String, Integer> nameToObjectId = new HashMap<>();
+    private final Set<Integer> trackedObjectIds = new LinkedHashSet<>();
+
+    public synchronized void handleUpdate(UpdatePacket packet) {
+        for (ObjectData data : packet.newObjects) {
+            if (data == null || data.status == null) {
+                continue;
+            }
+            if (!isPlayer(data.status.stats)) {
+                continue;
+            }
+            TrackedPlayer player = playersByObjectId.computeIfAbsent(data.status.objectId, TrackedPlayer::new);
+            player.setObjectType(data.objectType, IdToAsset.objectName(data.objectType));
+            player.updateFromStats(data.status.stats);
+            String currentName = player.getName();
+            if (currentName != null) {
+                nameToObjectId.put(currentName.toLowerCase(), data.status.objectId);
+            }
+        }
+
+        for (int drop : packet.drops) {
+            TrackedPlayer removed = playersByObjectId.get(drop);
+            if (removed != null) {
+                removed.markInactive();
+            }
+        }
+    }
+
+    public synchronized void handleNewTick(NewTickPacket packet) {
+        for (ObjectStatusData status : packet.status) {
+            TrackedPlayer player = playersByObjectId.get(status.objectId);
+            if (player == null) {
+                if (!isPlayer(status.stats)) {
+                    continue;
+                }
+                player = new TrackedPlayer(status.objectId);
+                playersByObjectId.put(status.objectId, player);
+            }
+            player.updateFromStats(status.stats);
+        }
+    }
+
+    public synchronized void handleDamage(DamagePacket packet) {
+        TrackedPlayer attacker = playersByObjectId.get(packet.objectId);
+        if (attacker != null) {
+            attacker.recordDamage(packet.damageAmount);
+        }
+        // Track healing via HP updates in the tick stream.
+    }
+
+    public synchronized void markTracked(int objectId, boolean tracked) {
+        if (tracked) {
+            trackedObjectIds.add(objectId);
+        } else {
+            trackedObjectIds.remove(objectId);
+        }
+    }
+
+    public synchronized void markTrackedByName(String name, boolean tracked) {
+        if (name == null) {
+            return;
+        }
+        Integer objectId = nameToObjectId.get(name.toLowerCase());
+        if (objectId != null) {
+            markTracked(objectId, tracked);
+        }
+    }
+
+    public synchronized List<PlayerSnapshot> getTrackedPlayers() {
+        return trackedObjectIds.stream()
+                .map(playersByObjectId::get)
+                .filter(p -> p != null)
+                .map(p -> p.toSnapshot(true))
+                .sorted(Comparator.comparingLong((PlayerSnapshot s) -> s.lastSeen).reversed())
+                .collect(Collectors.toList());
+    }
+
+    public synchronized List<PlayerSnapshot> getAllPlayers() {
+        List<PlayerSnapshot> snapshots = new ArrayList<>();
+        for (TrackedPlayer player : playersByObjectId.values()) {
+            boolean tracked = trackedObjectIds.contains(player.getObjectId());
+            snapshots.add(player.toSnapshot(tracked));
+        }
+        snapshots.sort(Comparator.comparing((PlayerSnapshot s) -> !s.active)
+                .thenComparing((PlayerSnapshot s) -> !s.tracked)
+                .thenComparing((PlayerSnapshot s) -> s.name == null ? "" : s.name.toLowerCase()));
+        return snapshots;
+    }
+
+    public synchronized void clearInactive() {
+        playersByObjectId.values().removeIf(player -> !player.isActive());
+        trackedObjectIds.removeIf(id -> !playersByObjectId.containsKey(id));
+        rebuildNameIndex();
+    }
+
+    public synchronized void reset() {
+        playersByObjectId.clear();
+        trackedObjectIds.clear();
+        nameToObjectId.clear();
+    }
+
+    private boolean isPlayer(StatData[] stats) {
+        if (stats == null) {
+            return false;
+        }
+        for (StatData stat : stats) {
+            if (stat.statType == StatType.ACCOUNT_ID_STAT) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void rebuildNameIndex() {
+        nameToObjectId.clear();
+        for (TrackedPlayer player : playersByObjectId.values()) {
+            String name = player.getName();
+            if (name != null) {
+                nameToObjectId.put(name.toLowerCase(), player.getObjectId());
+            }
+        }
+    }
+}

--- a/src/main/java/realmshark/service/SnifferController.java
+++ b/src/main/java/realmshark/service/SnifferController.java
@@ -1,0 +1,111 @@
+package realmshark.service;
+
+import packets.Packet;
+import packets.PacketType;
+import packets.incoming.DamagePacket;
+import packets.incoming.NewTickPacket;
+import packets.incoming.UpdatePacket;
+import packets.packetcapture.PacketProcessor;
+import packets.packetcapture.register.IPacketListener;
+import packets.packetcapture.register.Register;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Coordinates the low level packet processor with the high level player tracking service.
+ */
+public class SnifferController {
+
+    private final PlayerTracker playerTracker = new PlayerTracker();
+    private PacketProcessor processor;
+    private boolean running;
+    private boolean listenersRegistered;
+    private final List<Consumer<Boolean>> statusListeners = new CopyOnWriteArrayList<>();
+
+    private final IPacketListener<Packet> updateListener = packet ->
+            playerTracker.handleUpdate((UpdatePacket) packet);
+    private final IPacketListener<Packet> tickListener = packet ->
+            playerTracker.handleNewTick((NewTickPacket) packet);
+    private final IPacketListener<Packet> damageListener = packet ->
+            playerTracker.handleDamage((DamagePacket) packet);
+
+    public SnifferController() {
+    }
+
+    public PlayerTracker getPlayerTracker() {
+        return playerTracker;
+    }
+
+    public synchronized void startSniffer() {
+        if (running) {
+            return;
+        }
+        registerListeners();
+        processor = new PacketProcessor();
+        processor.setName("RealmShark-Sniffer");
+        processor.start();
+        running = true;
+        notifyStatus(true);
+    }
+
+    public synchronized void stopSniffer() {
+        if (!running) {
+            return;
+        }
+        try {
+            if (processor != null) {
+                processor.stopSniffer();
+                processor.closeSniffer();
+            }
+        } finally {
+            running = false;
+            processor = null;
+            notifyStatus(false);
+        }
+    }
+
+    public synchronized void shutdown() {
+        stopSniffer();
+        unregisterListeners();
+    }
+
+    private void registerListeners() {
+        if (listenersRegistered) {
+            return;
+        }
+        Register.INSTANCE.register(PacketType.UPDATE, updateListener);
+        Register.INSTANCE.register(PacketType.NEWTICK, tickListener);
+        Register.INSTANCE.register(PacketType.DAMAGE, damageListener);
+        listenersRegistered = true;
+    }
+
+    private void unregisterListeners() {
+        if (!listenersRegistered) {
+            return;
+        }
+        Register.INSTANCE.unregister(PacketType.UPDATE, updateListener);
+        Register.INSTANCE.unregister(PacketType.NEWTICK, tickListener);
+        Register.INSTANCE.unregister(PacketType.DAMAGE, damageListener);
+        listenersRegistered = false;
+    }
+
+    public void addStatusListener(Consumer<Boolean> listener) {
+        statusListeners.add(listener);
+    }
+
+    public void removeStatusListener(Consumer<Boolean> listener) {
+        statusListeners.remove(listener);
+    }
+
+    private void notifyStatus(boolean running) {
+        for (Consumer<Boolean> listener : statusListeners) {
+            listener.accept(running);
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/src/main/java/realmshark/ui/PlayerDashboardPanel.java
+++ b/src/main/java/realmshark/ui/PlayerDashboardPanel.java
@@ -1,0 +1,68 @@
+package realmshark.ui;
+
+import realmshark.model.PlayerSnapshot;
+import realmshark.ui.components.PlayerCard;
+
+import javax.swing.JPanel;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Grid based container that showcases the currently tracked players.
+ */
+public class PlayerDashboardPanel extends JPanel {
+
+    private static final int MAX_PLAYERS = 4;
+
+    private final List<PlayerCard> playerCards = new ArrayList<>();
+    private final JLabel emptyState;
+
+    public PlayerDashboardPanel() {
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(16, 16, 16, 12));
+        setBackground(new Color(30, 31, 34));
+
+        JPanel grid = new JPanel(new GridLayout(2, 2, 16, 16));
+        grid.setOpaque(false);
+
+        for (int i = 0; i < MAX_PLAYERS; i++) {
+            PlayerCard card = new PlayerCard();
+            card.update(null);
+            playerCards.add(card);
+            grid.add(card);
+        }
+
+        emptyState = new JLabel("No players tracked yet", SwingConstants.CENTER);
+        emptyState.setFont(emptyState.getFont().deriveFont(Font.PLAIN, 18f));
+        emptyState.setForeground(new Color(180, 189, 198));
+        emptyState.setBorder(new EmptyBorder(32, 0, 32, 0));
+
+        add(emptyState, BorderLayout.NORTH);
+        add(grid, BorderLayout.CENTER);
+        toggleEmptyState(true);
+    }
+
+    public void updatePlayers(List<PlayerSnapshot> players) {
+        int count = players == null ? 0 : players.size();
+        toggleEmptyState(count == 0);
+        for (int i = 0; i < playerCards.size(); i++) {
+            PlayerCard card = playerCards.get(i);
+            if (players != null && i < players.size()) {
+                card.update(players.get(i));
+            } else {
+                card.update(null);
+            }
+        }
+    }
+
+    private void toggleEmptyState(boolean show) {
+        emptyState.setVisible(show);
+    }
+}

--- a/src/main/java/realmshark/ui/PlayerListPanel.java
+++ b/src/main/java/realmshark/ui/PlayerListPanel.java
@@ -1,0 +1,232 @@
+package realmshark.ui;
+
+import realmshark.model.PlayerSnapshot;
+import realmshark.service.SnifferController;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableRowSorter;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Sidebar displaying the available players and offering quick tracking toggles.
+ */
+public class PlayerListPanel extends JPanel {
+
+    private final PlayerTableModel tableModel;
+    private final JTable table;
+    private final TableRowSorter<PlayerTableModel> sorter;
+    private final JTextField filterField;
+    private final SnifferController controller;
+
+    public PlayerListPanel(SnifferController controller) {
+        this.controller = controller;
+        setLayout(new BorderLayout());
+        setBorder(new EmptyBorder(16, 12, 16, 16));
+        setBackground(new Color(26, 27, 30));
+        setPreferredSize(new Dimension(340, 0));
+
+        JLabel title = new JLabel("Guild & Friends", SwingConstants.LEFT);
+        title.setForeground(new Color(215, 218, 224));
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 18f));
+        title.setBorder(new EmptyBorder(0, 0, 12, 0));
+        add(title, BorderLayout.NORTH);
+
+        tableModel = new PlayerTableModel();
+        table = new JTable(tableModel);
+        table.setFillsViewportHeight(true);
+        table.setRowHeight(28);
+        table.setShowGrid(false);
+        table.setIntercellSpacing(new Dimension(0, 0));
+        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        table.setBackground(new Color(37, 38, 41));
+        table.setForeground(new Color(220, 220, 220));
+        table.setOpaque(true);
+        table.getTableHeader().setBackground(new Color(45, 47, 50));
+        table.getTableHeader().setForeground(new Color(200, 200, 200));
+        table.getTableHeader().setReorderingAllowed(false);
+
+        DefaultTableCellRenderer center = new DefaultTableCellRenderer();
+        center.setHorizontalAlignment(SwingConstants.CENTER);
+        table.getColumnModel().getColumn(0).setMaxWidth(60);
+        table.getColumnModel().getColumn(0).setPreferredWidth(60);
+        table.getColumnModel().getColumn(3).setCellRenderer(center);
+        table.getColumnModel().getColumn(4).setCellRenderer(center);
+        table.getColumnModel().getColumn(5).setCellRenderer(center);
+
+        sorter = new TableRowSorter<>(tableModel);
+        table.setRowSorter(sorter);
+
+        JScrollPane scrollPane = new JScrollPane(table);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        add(scrollPane, BorderLayout.CENTER);
+
+        filterField = new JTextField();
+        filterField.setToolTipText("Filter by player or guild name");
+        filterField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                applyFilter();
+            }
+        });
+        filterField.setBackground(new Color(37, 38, 41));
+        filterField.setForeground(new Color(220, 220, 220));
+        filterField.setCaretColor(new Color(220, 220, 220));
+        filterField.setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(60, 63, 65)),
+                new EmptyBorder(6, 8, 6, 8)));
+
+        JLabel filterLabel = new JLabel("Search", SwingConstants.LEFT);
+        filterLabel.setForeground(new Color(160, 165, 172));
+        filterLabel.setBorder(new EmptyBorder(12, 0, 6, 0));
+
+        JPanel filterPanel = new JPanel(new BorderLayout());
+        filterPanel.setOpaque(false);
+        filterPanel.add(filterLabel, BorderLayout.NORTH);
+        filterPanel.add(filterField, BorderLayout.CENTER);
+        add(filterPanel, BorderLayout.SOUTH);
+    }
+
+    public void setPlayers(List<PlayerSnapshot> players) {
+        SwingUtilities.invokeLater(() -> {
+            tableModel.setPlayers(players);
+            applyFilter();
+        });
+    }
+
+    private void applyFilter() {
+        String text = filterField.getText();
+        if (text == null || text.trim().isEmpty()) {
+            sorter.setRowFilter(null);
+            return;
+        }
+        String lower = text.trim().toLowerCase();
+        sorter.setRowFilter(new RowFilter<PlayerTableModel, Integer>() {
+            @Override
+            public boolean include(Entry<? extends PlayerTableModel, ? extends Integer> entry) {
+                PlayerSnapshot snapshot = tableModel.getPlayerAt(entry.getModelRow());
+                if (snapshot == null) {
+                    return true;
+                }
+                String name = snapshot.name == null ? "" : snapshot.name.toLowerCase();
+                String guild = snapshot.guild == null ? "" : snapshot.guild.toLowerCase();
+                return name.contains(lower) || guild.contains(lower);
+            }
+        });
+    }
+
+    private class PlayerTableModel extends AbstractTableModel {
+        private final String[] columns = {"Track", "Player", "Guild", "DPS", "HPS", "Status"};
+        private final DecimalFormat rateFormat = new DecimalFormat("#,##0");
+        private List<PlayerSnapshot> players = new ArrayList<>();
+
+        public void setPlayers(List<PlayerSnapshot> players) {
+            this.players = players == null ? new ArrayList<>() : new ArrayList<>(players);
+            fireTableDataChanged();
+        }
+
+        @Override
+        public int getRowCount() {
+            return players.size();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columns.length;
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return columns[column];
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            if (columnIndex == 0) {
+                return Boolean.class;
+            }
+            return String.class;
+        }
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return columnIndex == 0;
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            PlayerSnapshot snapshot = players.get(rowIndex);
+            switch (columnIndex) {
+                case 0:
+                    return snapshot.tracked;
+                case 1:
+                    String name = snapshot.name == null ? "Unknown" : snapshot.name;
+                    return snapshot.level > 0 ? name + "  (Lv." + snapshot.level + ")" : name;
+                case 2:
+                    return snapshot.guild == null || snapshot.guild.isEmpty() ? "-" : snapshot.guild;
+                case 3:
+                    return formatRate(snapshot.dps);
+                case 4:
+                    return formatRate(snapshot.hps);
+                case 5:
+                    return snapshot.active ? "Active" : "Idle";
+                default:
+                    return "";
+            }
+        }
+
+        @Override
+        public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+            if (columnIndex != 0 || rowIndex >= players.size()) {
+                return;
+            }
+            PlayerSnapshot snapshot = players.get(rowIndex);
+            boolean track = Boolean.TRUE.equals(aValue);
+            controller.getPlayerTracker().markTracked(snapshot.objectId, track);
+            setPlayers(controller.getPlayerTracker().getAllPlayers());
+        }
+
+        private String formatRate(double value) {
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                return "0";
+            }
+            return rateFormat.format(value);
+        }
+
+        public PlayerSnapshot getPlayerAt(int index) {
+            if (index < 0 || index >= players.size()) {
+                return null;
+            }
+            return players.get(index);
+        }
+    }
+}

--- a/src/main/java/realmshark/ui/RealmSharkFrame.java
+++ b/src/main/java/realmshark/ui/RealmSharkFrame.java
@@ -1,0 +1,129 @@
+package realmshark.ui;
+
+import realmshark.model.PlayerSnapshot;
+import realmshark.service.PlayerTracker;
+import realmshark.service.SnifferController;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.List;
+
+/**
+ * Root application frame that composes the refreshed RealmShark UI.
+ */
+public class RealmSharkFrame extends JFrame {
+
+    private final SnifferController controller;
+    private final PlayerDashboardPanel dashboardPanel;
+    private final PlayerListPanel listPanel;
+    private final JLabel statusLabel;
+    private final Timer refreshTimer;
+
+    public RealmSharkFrame(SnifferController controller) {
+        super("RealmShark – Friends & Guild Dashboard");
+        this.controller = controller;
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(new BorderLayout());
+        setPreferredSize(new Dimension(1200, 720));
+        setMinimumSize(new Dimension(960, 600));
+
+        JPanel header = buildHeader();
+        add(header, BorderLayout.NORTH);
+
+        dashboardPanel = new PlayerDashboardPanel();
+        add(dashboardPanel, BorderLayout.CENTER);
+
+        listPanel = new PlayerListPanel(controller);
+        add(listPanel, BorderLayout.EAST);
+
+        pack();
+        setLocationRelativeTo(null);
+
+        controller.addStatusListener(this::updateStatus);
+
+        refreshTimer = new Timer(750, e -> refreshData());
+        refreshTimer.setRepeats(true);
+        refreshTimer.start();
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                controller.shutdown();
+                refreshTimer.stop();
+            }
+        });
+    }
+
+    private JPanel buildHeader() {
+        JPanel header = new JPanel(new BorderLayout());
+        header.setBorder(new EmptyBorder(16, 20, 16, 20));
+        header.setBackground(new Color(24, 24, 26));
+
+        JLabel title = new JLabel("RealmShark", SwingConstants.LEFT);
+        title.setForeground(new Color(224, 225, 228));
+        title.setFont(title.getFont().deriveFont(Font.BOLD, 24f));
+        header.add(title, BorderLayout.WEST);
+
+        JPanel controls = new JPanel(new FlowLayout(FlowLayout.RIGHT, 12, 0));
+        controls.setOpaque(false);
+
+        JButton startButton = new JButton("Start Sniffer");
+        startButton.addActionListener(e -> controller.startSniffer());
+        JButton stopButton = new JButton("Stop");
+        stopButton.addActionListener(e -> controller.stopSniffer());
+
+        styleButton(startButton, new Color(76, 175, 80));
+        styleButton(stopButton, new Color(229, 115, 115));
+
+        controls.add(startButton);
+        controls.add(stopButton);
+
+        statusLabel = new JLabel("Sniffer stopped", SwingConstants.RIGHT);
+        statusLabel.setForeground(new Color(200, 200, 200));
+        statusLabel.setBorder(new EmptyBorder(0, 16, 0, 0));
+        controls.add(statusLabel);
+
+        header.add(controls, BorderLayout.EAST);
+        return header;
+    }
+
+    private void styleButton(JButton button, Color background) {
+        button.setFocusPainted(false);
+        button.setForeground(Color.WHITE);
+        button.setBackground(background);
+        button.setOpaque(true);
+        button.setBorder(new EmptyBorder(8, 16, 8, 16));
+    }
+
+    private void refreshData() {
+        PlayerTracker tracker = controller.getPlayerTracker();
+        List<PlayerSnapshot> trackedPlayers = tracker.getTrackedPlayers();
+        dashboardPanel.updatePlayers(trackedPlayers);
+        listPanel.setPlayers(tracker.getAllPlayers());
+    }
+
+    private void updateStatus(boolean running) {
+        SwingUtilities.invokeLater(() -> {
+            if (running) {
+                statusLabel.setText("Sniffer running");
+                statusLabel.setForeground(new Color(129, 199, 132));
+            } else {
+                statusLabel.setText("Sniffer stopped");
+                statusLabel.setForeground(new Color(239, 154, 154));
+            }
+        });
+    }
+}

--- a/src/main/java/realmshark/ui/components/PlayerCard.java
+++ b/src/main/java/realmshark/ui/components/PlayerCard.java
@@ -1,0 +1,156 @@
+package realmshark.ui.components;
+
+import realmshark.model.PlayerSnapshot;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.SwingConstants;
+import javax.swing.border.EmptyBorder;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.GridLayout;
+import java.text.DecimalFormat;
+
+/**
+ * Compact UI card that visualises a single tracked player's performance metrics.
+ */
+public class PlayerCard extends JPanel {
+
+    private static final DecimalFormat RATE_FORMAT = new DecimalFormat("#,##0.0");
+    private static final DecimalFormat TOTAL_FORMAT = new DecimalFormat("#,##0");
+
+    private final JLabel nameLabel = new JLabel("--", SwingConstants.LEFT);
+    private final JLabel guildLabel = new JLabel("", SwingConstants.LEFT);
+    private final JLabel classLabel = new JLabel("", SwingConstants.LEFT);
+    private final JLabel dpsLabel = new JLabel("DPS: 0", SwingConstants.LEFT);
+    private final JLabel hpsLabel = new JLabel("HPS: 0", SwingConstants.LEFT);
+    private final JLabel totalDamageLabel = new JLabel("Total Damage: 0", SwingConstants.LEFT);
+    private final JLabel totalHealingLabel = new JLabel("Total Healing: 0", SwingConstants.LEFT);
+    private final JLabel statusLabel = new JLabel("Inactive", SwingConstants.LEFT);
+    private final JProgressBar hpBar = new JProgressBar();
+
+    public PlayerCard() {
+        setLayout(new BorderLayout(0, 12));
+        setBorder(BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(new Color(60, 63, 65)),
+                new EmptyBorder(12, 16, 12, 16)));
+        setBackground(new Color(43, 45, 48));
+
+        nameLabel.setFont(nameLabel.getFont().deriveFont(Font.BOLD, 18f));
+        nameLabel.setForeground(Color.WHITE);
+        guildLabel.setForeground(new Color(173, 186, 199));
+        classLabel.setForeground(new Color(173, 186, 199));
+        statusLabel.setForeground(new Color(120, 200, 120));
+
+        JPanel header = new JPanel(new GridLayout(0, 1));
+        header.setOpaque(false);
+        header.add(nameLabel);
+        header.add(guildLabel);
+        header.add(classLabel);
+        add(header, BorderLayout.NORTH);
+
+        hpBar.setStringPainted(true);
+        hpBar.setMinimum(0);
+        hpBar.setMaximum(1);
+        hpBar.setValue(0);
+        hpBar.setForeground(new Color(94, 167, 255));
+        add(hpBar, BorderLayout.CENTER);
+
+        JPanel metrics = new JPanel(new GridLayout(0, 1, 0, 4));
+        metrics.setOpaque(false);
+        dpsLabel.setForeground(Color.WHITE);
+        hpsLabel.setForeground(Color.WHITE);
+        totalDamageLabel.setForeground(new Color(200, 200, 200));
+        totalHealingLabel.setForeground(new Color(200, 200, 200));
+        statusLabel.setForeground(new Color(173, 186, 199));
+        metrics.add(dpsLabel);
+        metrics.add(hpsLabel);
+        metrics.add(totalDamageLabel);
+        metrics.add(totalHealingLabel);
+        metrics.add(statusLabel);
+        add(metrics, BorderLayout.SOUTH);
+    }
+
+    public void update(PlayerSnapshot snapshot) {
+        if (snapshot == null) {
+            renderPlaceholder();
+            return;
+        }
+        String displayName = snapshot.name == null ? "Unknown" : snapshot.name;
+        nameLabel.setText(displayName + (snapshot.level > 0 ? "  •  Lv." + snapshot.level : ""));
+        guildLabel.setText(snapshot.guild == null || snapshot.guild.isEmpty() ? "" : snapshot.guild);
+        classLabel.setText(snapshot.playerClass == null || snapshot.playerClass.isEmpty()
+                ? "Object #" + snapshot.objectType
+                : snapshot.playerClass);
+        statusLabel.setText(snapshot.active ? "Active" : "Last seen " + formatLastSeen(snapshot.lastSeen));
+        statusLabel.setForeground(snapshot.active ? new Color(140, 220, 140) : new Color(200, 170, 120));
+
+        hpBar.setMaximum(Math.max(snapshot.maxHp, 1));
+        hpBar.setValue(Math.max(snapshot.currentHp, 0));
+        hpBar.setString(formatHp(snapshot.currentHp, snapshot.maxHp));
+
+        dpsLabel.setText("DPS: " + formatRate(snapshot.dps));
+        hpsLabel.setText("HPS: " + formatRate(snapshot.hps));
+        totalDamageLabel.setText("Total Damage: " + formatTotal(snapshot.totalDamage));
+        totalHealingLabel.setText("Total Healing: " + formatTotal(snapshot.totalHealing));
+    }
+
+    private void renderPlaceholder() {
+        nameLabel.setText("No player selected");
+        guildLabel.setText("Choose a player from the roster to begin tracking.");
+        classLabel.setText("");
+        statusLabel.setText("Idle");
+        statusLabel.setForeground(new Color(173, 186, 199));
+        hpBar.setMaximum(1);
+        hpBar.setValue(0);
+        hpBar.setString("0 / 0");
+        dpsLabel.setText("DPS: 0");
+        hpsLabel.setText("HPS: 0");
+        totalDamageLabel.setText("Total Damage: 0");
+        totalHealingLabel.setText("Total Healing: 0");
+    }
+
+    private String formatHp(int hp, int maxHp) {
+        if (hp < 0 || maxHp <= 0) {
+            return "--";
+        }
+        return hp + " / " + maxHp;
+    }
+
+    private String formatRate(double rate) {
+        if (Double.isNaN(rate) || Double.isInfinite(rate)) {
+            return "0";
+        }
+        if (rate >= 1000) {
+            return RATE_FORMAT.format(rate / 1000d) + "k";
+        }
+        return RATE_FORMAT.format(rate);
+    }
+
+    private String formatTotal(long value) {
+        if (value <= 0) {
+            return "0";
+        }
+        return TOTAL_FORMAT.format(value);
+    }
+
+    private String formatLastSeen(long lastSeen) {
+        long diff = Math.max(0, System.currentTimeMillis() - lastSeen);
+        long seconds = diff / 1000L;
+        if (seconds < 5) {
+            return "just now";
+        }
+        if (seconds < 60) {
+            return seconds + "s ago";
+        }
+        long minutes = seconds / 60;
+        if (minutes < 60) {
+            return minutes + "m ago";
+        }
+        long hours = minutes / 60;
+        return hours + "h ago";
+    }
+}


### PR DESCRIPTION
## Summary
- add a new Swing-based RealmShark frame with streamlined controls and roster dashboard
- implement player tracking services that compute per-player DPS/HPS metrics from packet data
- build modern UI components (player cards and roster table) tailored to friends and guild monitoring

## Testing
- ⚠️ `bash gradlew test` *(fails: Gradle wrapper is not present in the repository so the wrapper main class cannot be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c241142c832cb65560fed7f0a884